### PR TITLE
constructor - deprecated standard

### DIFF
--- a/contracts/Election.sol
+++ b/contracts/Election.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.2;
 contract Election {
     string public candidateName;
 
-    function Election () public {
+    constructor () public {
         candidateName = "Candidate 1";
     }
 


### PR DESCRIPTION
This is because of a deprecated standard. In the file, replace the line:

function Election () public {
with:
constructor() public {
The line of code shown just above is a constructor, it runs on a contract's deployment, and it is used(as in the file in context) to save the contract owner's address(msg.sender varies based on who interacts with the contract).
This replaces the existing implementation of using a function with the same name as the contract to act as a constructor with a separate constructor function.